### PR TITLE
exclude jul-to-slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client</artifactId>
         <version>3.1.8</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Add an exclusion to `jul-to-slf4j` because 

1) jenkins uses j.u.l.
2) if it didn't it needs to be done at the app server (Jenkins) level not in a plugin