### PR TITLE
Update fabric8io/kubernetes-client version from 3.1.8 to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client</artifactId>
-        <version>3.1.8</version>
+        <version>4.1.1</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
3.1.8 is not working if ca.crf ended with redundant line

```
SEVERE: Failed to initialise k8s secret provider, secrets from Kubernetes will not be available
io.fabric8.kubernetes.client.KubernetesClientException: An error has occurred.
	at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:62)
	at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:53)
	at io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClient(HttpClientUtils.java:168)
	at io.fabric8.kubernetes.client.BaseClient.<init>(BaseClient.java:55)
	at io.fabric8.kubernetes.client.DefaultKubernetesClient.<init>(DefaultKubernetesClient.java:78)
	at com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.startWatchingForSecrets(KubernetesCredentialProvider.java:81)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1083)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.security.cert.CertificateException: Could not parse certificate: java.io.IOException: Empty input
	at sun.security.provider.X509Factory.engineGenerateCertificate(X509Factory.java:110)
	at java.security.cert.CertificateFactory.generateCertificate(CertificateFactory.java:339)
	at io.fabric8.kubernetes.client.internal.CertUtils.createTrustStore(CertUtils.java:93)
	at io.fabric8.kubernetes.client.internal.CertUtils.createTrustStore(CertUtils.java:71)
	at io.fabric8.kubernetes.client.internal.SSLUtils.trustManagers(SSLUtils.java:114)
	at io.fabric8.kubernetes.client.internal.SSLUtils.trustManagers(SSLUtils.java:93)
	at io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClient(HttpClientUtils.java:63)
	... 16 more
Caused by: java.io.IOException: Empty input
	at sun.security.provider.X509Factory.engineGenerateCertificate(X509Factory.java:106)
	... 22 more
```