### PR TITLE
Add static getInstance method

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -153,7 +153,7 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
      * @return the singleton instance.
      */
     public static KubernetesCredentialProvider getInstance() {
-        return ExtensionList.lookup(KubernetesCredentialProvider.class).get(KubernetesCredentialProvider.class);
+        return ExtensionList.lookupSingleton(KubernetesCredentialProvider.class);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -29,8 +29,11 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.client.Config;
@@ -144,6 +147,15 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
     private final @NonNull <T> List<T> emptyList() {
         // just a separate method to avoid having to suppress "null" for the entirety of getCredentials
         return Collections.emptyList();
+    }
+
+    /**
+     * Gets the singleton instance.
+     *
+     * @return the singleton instance.
+     */
+    public static KubernetesCredentialProvider getInstance() {
+        return ExtensionList.lookup(KubernetesCredentialProvider.class).get(KubernetesCredentialProvider.class);
     }
 
     @Override


### PR DESCRIPTION
Inspired in the [`SystemCredentialsProvider`](https://github.com/jenkinsci/credentials-plugin/blob/master/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java#L144), this change will allow getting a singleton instance of the `KubernetesCredentialProvider`.

This is useful for the test suite implementation and also to access the k8s credentials provider from groovy initialization scripts, example:

```
import com.cloudbees.plugins.credentials.domains.Domain
import com.cloudbees.plugins.credentials.CredentialsStore
import com.cloudbees.plugins.credentials.Credentials
import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider
import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialsStore
import jenkins.model.Jenkins

KubernetesCredentialProvider k8sProvider = KubernetesCredentialProvider.getInstance()
KubernetesCredentialsStore k8sStore = k8sProvider.getStore(Jenkins.instance)
List<Credentials> k8sCredentials = k8sStore.getCredentials(Domain.global())

println k8sCredentials.findResult { it.id == 'my-credential-username-password' ? it : [:] }.username
println k8sCredentials.findResult { it.id == 'my-credential-username-password' ? it : [:] }.password

=>
foo
bar
```