### PR TITLE
Secret label selector configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,13 @@ Because granting these permissions for secrets is not something that should be d
 
 Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [examples](examples) page.
 
+To restrict the secrets add by this plugin use the system property `com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector`
+to set the [Kubernetes Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) expression.
+
+```
+-Dcom.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector="env in (iat uat)"
+```
+
 ### Updating credentials
 
 Credentials are updated automatically when changes are made to the Kubernetes secret.

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorExpressions.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorExpressions.java
@@ -1,0 +1,83 @@
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+
+/**
+ * Parser for <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">Kubernetes Label Selectors</a>.
+ */
+class LabelSelectorExpressions {
+
+    /**
+     * Parse Kubernetes label selector expression.
+     * Example:
+     * <pre>
+     * app in (jenkins-dev, jenkins-all)
+     * </pre>
+     * @param selector label selector expression or null
+     * @return parsed label selector
+     */
+    @NonNull
+    static LabelSelector parse(String selector) {
+        LabelSelectorBuilder lsb = new LabelSelectorBuilder();
+        if (selector != null && !selector.trim().isEmpty()) {
+            Matcher matcher = Pattern.compile("[^,]+?\\([^()]+\\)|[^,]+").matcher(selector);
+            while (matcher.find()) {
+                String expression = matcher.group();
+                expression = expression.replaceFirst("!=|=", " $0 ");
+                String[] tokens = expression.trim().split("\\s+", 3);
+                switch (tokens.length) {
+                    case 1:
+                        if (tokens[0].startsWith("!")) {
+                            lsb.addNewMatchExpression()
+                                    .withKey(tokens[0].substring(1))
+                                    .withOperator("DoesNotExist")
+                                    .endMatchExpression();
+                        } else {
+                            lsb.addNewMatchExpression()
+                                    .withKey(tokens[0])
+                                    .withOperator("Exists")
+                                    .endMatchExpression();
+                        }
+                        break;
+                    case 2:
+                        // not valid
+                        break;
+                    case 3:
+                        String operator = tokens[1];
+                        if ("=".equals(operator)) {
+                            lsb.addToMatchLabels(tokens[0], tokens[2]);
+                        } else if ("!=".equals(operator)) {
+                            lsb.addNewMatchExpression()
+                                    .withKey(tokens[0])
+                                    .withOperator("NotIn")
+                                    .withValues(tokens[2])
+                                    .endMatchExpression();
+                        } else if ("notin".equalsIgnoreCase(operator)) {
+                            lsb.addNewMatchExpression()
+                                    .withKey(tokens[0])
+                                    .withOperator("NotIn")
+                                    .withValues(values(tokens[2]))
+                                    .endMatchExpression();
+                        } else if ("in".equalsIgnoreCase(operator)) {
+                            lsb.addNewMatchExpression()
+                                    .withKey(tokens[0])
+                                    .withOperator("In")
+                                    .withValues(values(tokens[2]))
+                                    .endMatchExpression();
+                        }
+                        break;
+                }
+            }
+        }
+        return lsb.build();
+    }
+
+    private static String[] values(String list) {
+        return list.replaceAll("\\(|\\)", "").trim().split("\\s*,\\s*");
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorParseException.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorParseException.java
@@ -1,0 +1,17 @@
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider;
+
+/**
+ * Exception thrown for label selector parsing errors.
+ */
+class LabelSelectorParseException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create new label parse exception with no root cause.
+     * @param message exception message
+     */
+    LabelSelectorParseException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorExpressionsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorExpressionsTest.java
@@ -1,0 +1,44 @@
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider;
+
+import static org.junit.Assert.*;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import org.junit.Test;
+
+public class LabelSelectorExpressionsTest {
+
+    @Test
+    public void parse() {
+        LabelSelector selector = LabelSelectorExpressions.parse("partition  in  (customerA, customerB),environment!=qa,!foo,bar,color=blue,owner in ( john , mary )");
+
+        LabelSelector expected = new LabelSelectorBuilder()
+                .addToMatchLabels("color", "blue")
+                .addNewMatchExpression()
+                    .withKey("partition")
+                    .withOperator("In")
+                    .withValues("customerA", "customerB")
+                    .endMatchExpression()
+                .addNewMatchExpression()
+                    .withKey("environment")
+                    .withOperator("NotIn")
+                    .withValues("qa")
+                    .endMatchExpression()
+                .addNewMatchExpression()
+                    .withKey("foo")
+                    .withOperator("DoesNotExist")
+                    .endMatchExpression()
+                .addNewMatchExpression()
+                    .withKey("bar")
+                    .withOperator("Exists")
+                    .endMatchExpression()
+                .addNewMatchExpression()
+                    .withKey("owner")
+                    .withOperator("In")
+                    .withValues("john", "mary")
+                    .endMatchExpression()
+                .build();
+
+        assertEquals(expected, selector);
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorExpressionsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/LabelSelectorExpressionsTest.java
@@ -4,18 +4,22 @@ import static org.junit.Assert.*;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class LabelSelectorExpressionsTest {
 
+    public @Rule ExpectedException thrown = ExpectedException.none();
+
     @Test
-    public void parse() {
-        LabelSelector selector = LabelSelectorExpressions.parse("partition  in  (customerA, customerB),environment!=qa,!foo,bar,color=blue,owner in ( john , mary )");
+    public void parse() throws LabelSelectorParseException {
+        LabelSelector selector = LabelSelectorExpressions.parse("mycompany.com/partition  in  (customerA, customerB),environment!=qa,!foo,bar,color=blue,bingo notin (barn),owner in ( john , mary )");
 
         LabelSelector expected = new LabelSelectorBuilder()
                 .addToMatchLabels("color", "blue")
                 .addNewMatchExpression()
-                    .withKey("partition")
+                    .withKey("mycompany.com/partition")
                     .withOperator("In")
                     .withValues("customerA", "customerB")
                     .endMatchExpression()
@@ -33,6 +37,11 @@ public class LabelSelectorExpressionsTest {
                     .withOperator("Exists")
                     .endMatchExpression()
                 .addNewMatchExpression()
+                    .withKey("bingo")
+                    .withOperator("NotIn")
+                    .withValues("barn")
+                    .endMatchExpression()
+                .addNewMatchExpression()
                     .withKey("owner")
                     .withOperator("In")
                     .withValues("john", "mary")
@@ -40,5 +49,19 @@ public class LabelSelectorExpressionsTest {
                 .build();
 
         assertEquals(expected, selector);
+    }
+
+    @Test
+    public void parseInvalidOperator() throws LabelSelectorParseException {
+        thrown.expect(LabelSelectorParseException.class);
+        thrown.expectMessage("Unrecognized selector operator 'of' in expression");
+        LabelSelectorExpressions.parse("partition  of  (customerA, customerB)");
+    }
+
+    @Test
+    public void parseInvalidExpressionTokenCountTwo() throws LabelSelectorParseException {
+        thrown.expect(LabelSelectorParseException.class);
+        thrown.expectMessage("Invalid selector expression 'partition  in'. Expected 1 or 3 tokens, got 2: [partition, in]");
+        LabelSelectorExpressions.parse("partition  in");
     }
 }


### PR DESCRIPTION
Add a label selector configuration point to restrict the secrets picked up by this plugin. The syntax is based on the Kubernetes label selector api, https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

The use case for this is when there are multiple jenkins instance in a single namespace and you want to limit which secrets are available to
each instance.  For example, you might have some common secrets that are
applicable to both instances and others that should only be visibile to subset of
instances. With the label selector you can accomplish this by adding a selector
like so:

```yaml
# devops-jenkins-deployment.yaml
env:
  - name: JAVA_OPTS
     value: -Dcom.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector="mycompany.com/jenkins in (common devops)"
```

The secrets would then be configured with the selector labels
```yaml
# deveops-deploy-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: "devops-deploy"
  labels:
    "jenkins.io/credentials-type": "usernamePassword"
    mycompany.com/jenkins: devops
---
# common-user-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: "common-user"
  labels:
    "jenkins.io/credentials-type": "usernamePassword"
    mycompany.com/jenkins: common
---
# othergroup-user-secret.yaml
# This secret will NOT be in picked up by the devops jenkins instance
apiVersion: v1
kind: Secret
metadata:
  name: "othergroup-user"
  labels:
    "jenkins.io/credentials-type": "usernamePassword"
    mycompany.com/jenkins: othergroup
```

I couldn't think of a better way to configure this other than a system property.