### PR TITLE
Use proper credentials-type in AWS test resource

### DIFF
--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertorTest/valid-no-desc.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertorTest/valid-no-desc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "a-test-aws"
   labels:
 # so we know what type it is.
-    "jenkins.io/credentials-type": "usernamePassword"
+    "jenkins.io/credentials-type": "aws"
 type: Opaque
 data:
 # UTF-8 base64 encoded

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertorTest/validMissingIamMfa.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertorTest/validMissingIamMfa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "a-test-aws"
   labels:
 # so we know what type it is.
-    "jenkins.io/credentials-type": "usernamePassword"
+    "jenkins.io/credentials-type": "aws"
 type: Opaque
 data:
 # UTF-8 base64 encoded

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertorTest/validMissingIamRole.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertorTest/validMissingIamRole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "a-test-aws"
   labels:
 # so we know what type it is.
-    "jenkins.io/credentials-type": "usernamePassword"
+    "jenkins.io/credentials-type": "aws"
 type: Opaque
 data:
 # UTF-8 base64 encoded


### PR DESCRIPTION
The label `jenkins.io/credentials-type` is not used in the test implementation. So the tests did not fail, but the resources was still wrong.