### PR TITLE
Support AzureCredentials Credential Type

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -9,7 +9,7 @@ permalink: /examples/
 Credentials are added and updated by adding/updating them as secrets to Kubernetes.
 The format of the Secret is different depending on the type of credential you wish to expose, but will all have several things in common:
 
-- the label  `"jenkins.io/credentials-type"` with a type that is known to the plugin (e.g. `certificate`, `secretFile`, `secretText`, `usernamePassword`, `basicSSHUserPrivateKey`, `aws`, 'openstackCredentialv3')
+- the label  `"jenkins.io/credentials-type"` with a type that is known to the plugin (e.g. `certificate`, `secretFile`, `secretText`, `usernamePassword`, `basicSSHUserPrivateKey`, `aws`, `openstackCredentialv3`, `azure`)
 - an annotation for the credential description: `"jenkins.io/credentials-description" : "certificate credential from Kubernetes"`
 
 To add or update a Credential just execute the command `kubectl apply -f <nameOfFile.yaml>`
@@ -67,6 +67,12 @@ Only AWS AccessKey and SecretKey:
 
 {% highlight yaml linenos %}
 {% include_relative openstack-credential-v3.yaml %}
+{% endhighlight %}
+
+## Azure Credentials
+
+{% highlight yaml linenos %}
+{% include_relative azure-credentials.yaml %}
 {% endhighlight %}
 
 # Custom field mapping

--- a/docs/examples/azure-credentials.yaml
+++ b/docs/examples/azure-credentials.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "test-azure-credentials"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+stringData:
+  subscriptionId: mySubscriptionId
+  clientId: myClientId
+  clientSecret: mySecret

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>azure-credentials</artifactId>
+          <version>4.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>openstack-cloud</artifactId>
         <version>2.47</version>
         <exclusions>
@@ -191,6 +196,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
+      <optional>true</optional>
+    </dependency>
+      <!-- for Azure credentials -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>azure-credentials</artifactId>
       <optional>true</optional>
     </dependency>
       <!-- for Openstack credentials -->

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertor.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc., @hugomcfonseca
+ * Copyright 2020 @luka5
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import java.util.Optional;
+import com.microsoft.azure.util.AzureCredentials;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretUtils;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+
+/**
+ * SecretToCredentialConvertor that converts {@link AzureCredentials}.
+ */
+@OptionalExtension(requirePlugins={"azure-credentials"})
+public class AzureCredentialsConvertor extends SecretToCredentialConverter {
+
+    @Override
+    public boolean canConvert(String type) {
+        return "azure".equals(type);
+    }
+
+    @Override
+    public AzureCredentials convert(Secret secret) throws CredentialsConvertionException {
+
+        SecretUtils.requireNonNull(secret.getData(), "azure definition contains no data");
+
+        String subscriptionIdBase64 = SecretUtils.getNonNullSecretData(secret, "subscriptionId", "azure credential is missing the subscriptionId");
+
+        String clientIdBase64 = SecretUtils.getNonNullSecretData(secret, "clientId", "azure credential is missing the clientId");
+
+        String clientSecretBase64 = SecretUtils.getNonNullSecretData(secret, "clientSecret", "azure credential is missing the clientSecret");
+
+        String subscriptionId = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(subscriptionIdBase64), "azure credential has an invalid subscriptionId (must be base64 encoded UTF-8)");
+
+        String clientId = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(clientIdBase64), "azure credential has an invalid clientId (must be base64 encoded UTF-8)");
+
+        String clientSecret = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(clientSecretBase64), "azure credential has an invalid clientSecret (must be base64 encoded UTF-8)");
+
+        return new AzureCredentials(
+                // Scope
+                CredentialsScope.GLOBAL,
+                // ID
+                SecretUtils.getCredentialId(secret),
+                // Desc
+                SecretUtils.getCredentialDescription(secret),
+                // SubscriptionId
+                subscriptionId,
+                // ClientId
+                clientId,
+                // ClientSecret
+                clientSecret
+        );
+
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest.java
@@ -1,0 +1,212 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc., @hugomcfonseca
+ * Copyright 2020 @luka5
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.microsoft.azure.util.AzureCredentials;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.emptyString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests AzureCredentialsConvertor
+ */
+public class AzureCredentialsConvertorTest {
+
+    String subscriptionId = "test-subscription-id";
+    String clientId= "test-client-id";
+    String clientSecret = "u.&%(Z>yEZ8(}:uoy";
+
+    @Test
+    public void canConvert() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+        assertThat("correct registration of valid type", convertor.canConvert("azure"), is(true));
+        assertThat("incorrect type is rejected", convertor.canConvert("something"), is(false));
+    }
+
+    @Test
+    public void canConvertAValidSecret() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("valid.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            assertThat("The Secret was loaded correctly from disk", notNullValue());
+            AzureCredentials credential = convertor.convert(secret);
+            assertThat(credential, notNullValue());
+            assertThat("credential id is mapped correctly", credential.getId(), is("a-test-azure"));
+            assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+            assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+            assertThat("credential subscriptionId is mapped correctly", credential.getSubscriptionId(), is(subscriptionId));
+            assertThat("credential clientId is mapped correctly", credential.getClientId(), is(clientId));
+            assertThat("credential clientSecret is mapped correctly", credential.getClientSecret(), is(clientSecret));
+        }
+    }
+
+    @Test
+    public void canConvertAValidMappedSecret() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("validMapped.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            assertThat("The Secret was loaded correctly from disk", notNullValue());
+            AzureCredentials credential = convertor.convert(secret);
+            assertThat(credential, notNullValue());
+            assertThat("credential id is mapped correctly", credential.getId(), is("a-test-azure"));
+            assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+            assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+            assertThat("credential subscriptionId is mapped correctly", credential.getSubscriptionId(), is(subscriptionId));
+            assertThat("credential clientId is mapped correctly", credential.getClientId(), is(clientId));
+            assertThat("credential clientSecret is mapped correctly", credential.getClientSecret(), is(clientSecret));
+        }
+    }
+
+    @Test
+    public void canConvertAValidSecretWithNoDescription() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("valid-no-desc.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            assertThat("The Secret was loaded correctly from disk", notNullValue());
+            AzureCredentials credential = convertor.convert(secret);
+            assertThat(credential, notNullValue());
+            assertThat("credential id is mapped correctly", credential.getId(), is("a-test-azure"));
+            assertThat("credential description is mapped correctly", credential.getDescription(), is(emptyString()));
+            assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+            assertThat("credential subscriptionId is mapped correctly", credential.getSubscriptionId(), is(subscriptionId));
+            assertThat("credential clientId is mapped correctly", credential.getClientId(), is(clientId));
+            assertThat("credential clientSecret is mapped correctly", credential.getClientSecret(), is(clientSecret));
+        }
+    }
+
+    @Test
+    public void failsToConvertWhenSubscriptionIdMissing() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("missingSubscriptionId.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("missing the subscriptionId"));
+        }
+    }
+
+    @Test
+    public void failsToConvertWhenClientIdMissing() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("missingClientId.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("missing the clientId"));
+        }
+    }
+
+    @Test
+    public void failsToConvertWhenClientSecretMissing() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("missingClientSecret.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("missing the clientSecret"));
+        }
+    }
+
+    // BASE64 Corrupt
+    @Test
+    public void failsToConvertWhenSubscriptionIdCorrupt() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("corruptSubscriptionId.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("invalid subscriptionId"));
+        }
+    }
+
+    @Test
+    public void failsToConvertWhenClientIdCorrupt() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("corruptClientId.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("invalid clientId"));
+        }
+    }
+
+    @Test
+    public void failsToConvertWhenClientSecretCorrupt() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("corruptClientSecret.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("invalid clientSecret"));
+        }
+    }
+
+
+    @Test
+    public void failsToConvertWhenDataEmpty() throws Exception {
+        AzureCredentialsConvertor convertor = new AzureCredentialsConvertor();
+
+        try (InputStream is = get("void.yaml")) {
+            Secret secret = Serialization.unmarshal(is, Secret.class);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("contains no data"));
+        }
+    }
+
+
+    private static final InputStream get(String resource) {
+        InputStream is = AzureCredentialsConvertorTest.class.getResourceAsStream("AzureCredentialsConvertorTest/" + resource);
+        if (is == null) {
+            fail("failed to load resource " + resource);
+        }
+        return is;
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/corruptClientId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/corruptClientId.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  subscriptionId: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  clientId: hello                               #not base64
+  clientSecret: dS4mJShaPnlFWjgofTp1b3k=        #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/corruptClientSecret.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/corruptClientSecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  subscriptionId: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  clientId: dGVzdC1jbGllbnQtaWQ=                #test-client-id
+  clientSecret: hello                           #not base64

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/corruptSubscriptionId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/corruptSubscriptionId.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  subscriptionId: hello                         #not base64
+  clientId: dGVzdC1jbGllbnQtaWQ=                #test-client-id
+  clientSecret: dS4mJShaPnlFWjgofTp1b3k=        #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/missingClientId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/missingClientId.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  subscriptionId: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  clientSecret: dS4mJShaPnlFWjgofTp1b3k=        #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/missingClientSecret.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/missingClientSecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+    # so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+    # description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+  # UTF-8 base64 encoded
+  subscriptionId: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  clientId: dGVzdC1jbGllbnQtaWQ=                #test-client-id

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/missingSubscriptionId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/missingSubscriptionId.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  clientId: dGVzdC1jbGllbnQtaWQ=                #test-client-id
+  clientSecret: dS4mJShaPnlFWjgofTp1b3k=        #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/valid-no-desc.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/valid-no-desc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  subscriptionId: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  clientId: dGVzdC1jbGllbnQtaWQ=                #test-client-id
+  clientSecret: dS4mJShaPnlFWjgofTp1b3k=        #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/valid.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/valid.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  subscriptionId: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  clientId: dGVzdC1jbGllbnQtaWQ=                #test-client-id
+  clientSecret: dS4mJShaPnlFWjgofTp1b3k=        #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/validMapped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/validMapped.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+    # map the subscriptionId field to s
+    "jenkins.io/credentials-keybinding-subscriptionId" : "s"
+    # map the clientId field to ci
+    "jenkins.io/credentials-keybinding-clientId" : "ci"
+    # map the clientSecret field to cs
+    "jenkins.io/credentials-keybinding-clientSecret" : "cs"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  s: dGVzdC1zdWJzY3JpcHRpb24taWQ=  #test-subscription-id
+  ci: dGVzdC1jbGllbnQtaWQ=         #test-client-id
+  cs: dS4mJShaPnlFWjgofTp1b3k=     #u.&%(Z>yEZ8(}:uoy

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/void.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AzureCredentialsConvertorTest/void.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-azure"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "azure"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:


### PR DESCRIPTION
This PR implements support for the credential type `AzureCredentials` as provided by the [azure-credentials plugin](https://github.com/jenkinsci/azure-credentials-plugin). This one is useful, whenever a Jenkins is connected to or is running in Azure. In our use-case, we need this feature to provide a Azure service principal credential to set up the [azure-keyvault plugin](https://github.com/jenkinsci/azure-keyvault-plugin). This PR is implementation similar to the [aws-credentials plugin](https://github.com/jenkinsci/aws-credentials-plugin) in https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/commit/a0a25c3cf978c7c8eb074a2c468d66273630449c by @hugomcfonseca.

Unfortunately, I'm unable to build, run or test this implementation, due to issues in the maven dependencies. The `maven-plugin-enforcer` fails with multiple complains - one even within the `azure-credentials` package itself. I don't know how to resolve these issues. I also tried with https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/pull/41, but it still fails. Also running the tests without the enforcer is failing due to incompatible versions.

Can someone help me updating the pom? Or is it simply not possible?

Thanks!