### PR TITLE
[JENKINS-65211] mark the github app extension as optional

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/GitHubAppCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/GitHubAppCredentialsConvertor.java
@@ -29,11 +29,12 @@ import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretUtils
 import hudson.Extension;
 import io.fabric8.kubernetes.api.model.Secret;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 
 /**
  * SecretToCredentialConvertor that converts {@link GitHubAppCredentials}.
  */
-@Extension
+@OptionalExtension(requirePlugins={"github-branch-source"})
 public class GitHubAppCredentialsConvertor extends SecretToCredentialConverter {
 
     @Override


### PR DESCRIPTION
Extension is now optional and only loaded if the "github-branch-source" plugin is installed.

(I did not know this was a feature!)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
