### PR TITLE
feat: add External ID parameter to AWS converter

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AWSCredentialsConvertor.java
@@ -68,6 +68,13 @@ public class AWSCredentialsConvertor extends SecretToCredentialConverter {
         if (iamMfaSerialNumberBase64.isPresent()) {
             iamMfaSerialNumber = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(iamMfaSerialNumberBase64.get()), "aws credential has an invalid iamMfaSerialNumber (must be base64 encoded UTF-8)");
         }
+        
+        Optional<String> iamExternalIdBase64 = SecretUtils.getOptionalSecretData(secret, "iamExternalId", "aws credential: failed to retrieve optional parameter iamExternalId");
+        String iamExternalId = null;
+
+        if (iamExternalIdBase64.isPresent()) {
+            iamExternalId = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(iamExternalIdBase64.get()), "aws credential has an invalid iamExternalId (must be base64 encoded UTF-8)");
+        }
 
         return new AWSCredentialsImpl(
                 // Scope
@@ -83,7 +90,9 @@ public class AWSCredentialsConvertor extends SecretToCredentialConverter {
                 // IAM Role ARN
                 iamRoleArn,
                 // MFA
-                iamMfaSerialNumber
+                iamMfaSerialNumber,
+                // External ID
+                iamExternalId
         );
 
     }


### PR DESCRIPTION
certain credential plugins, like the credential-binding plugin, require that the externalID be specified when using IAM Roles and the aws credential type.

This will add the ability to optionally add iamExternalId in the same way that iamRoleArn is added

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
