### PR TITLE
[JENKINS-68327] feat: add vault credentials

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -76,6 +76,24 @@ Only AWS AccessKey and SecretKey:
 {% include_relative gitHubApp.yaml %}
 {% endhighlight %}
 
+## Vault AppRole
+
+{% highlight yaml linenos %}
+{% include_relative vault-approle.yaml %}
+{% endhighlight %}
+
+## Vault GitHub Token
+
+{% highlight yaml linenos %}
+{% include_relative vault-github.yaml %}
+{% endhighlight %}
+
+## Vault Token
+
+{% highlight yaml linenos %}
+{% include_relative vault-token.yaml %}
+{% endhighlight %}
+
 # Custom field mapping
 
 Sometimes you may want the secret to be able to be consumed by another tool as well that has a different requirement for the data fields.

--- a/docs/examples/vault-approle.yaml
+++ b/docs/examples/vault-approle.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "another-test-vault-approle"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+stringData:
+  roleId: db02de05-fa39-4855-059b-67221c5c2f63
+  secretId: 6a174c20-f6de-a53c-74d2-6018fcceff64
+# optional fields
+  path: approle-jenkins    # defaults to 'approle'
+  namespace: team1         # defaults to global vault jenkins configuration

--- a/docs/examples/vault-github.yaml
+++ b/docs/examples/vault-github.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "another-test-vault-github"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+stringData:
+  accessToken: db02de05-fa39-4855-059b-67221c5c2f63
+# optional fields
+  mountPath: github-jenkins    # defaults to 'github'
+  namespace: team1             # defaults to global vault jenkins configuration

--- a/docs/examples/vault-token.yaml
+++ b/docs/examples/vault-token.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "another-test-vault-token"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+stringData:
+  token: db02de05-fa39-4855-059b-67221c5c2f63

--- a/pom.xml
+++ b/pom.xml
@@ -78,24 +78,34 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>symbol-annotation</artifactId>
+        <version>1.22</version>
+      </dependency>
+      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.15</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials-binding</artifactId>
+        <version>1.24</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.17</version>
+        <version>1.22</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.14</version>
+        <version>2.23</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plain-credentials</artifactId>
-        <version>1.4</version>
+        <version>1.7</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -133,6 +143,11 @@
         <version>2.7.1</version>
       </dependency>
       <dependency>
+        <groupId>com.datapipe.jenkins.plugins</groupId>
+        <artifactId>hashicorp-vault-plugin</artifactId>
+        <version>3.8.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
         <version>2.2</version>
@@ -146,7 +161,6 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>jackson2-api</artifactId>
         <version>2.12.3</version>
-
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -159,7 +173,6 @@
         <version>1.15</version>
       </dependency>
     </dependencies>
-
   </dependencyManagement>
 
   <dependencies>
@@ -167,7 +180,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
       <version>5.4.1</version>
-
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -213,7 +225,13 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
       <optional>true</optional>
-    </dependency>    
+    </dependency>
+    <!-- HashiCorp Vault App credentials -->
+    <dependency>
+      <groupId>com.datapipe.jenkins.plugins</groupId>
+      <artifactId>hashicorp-vault-plugin</artifactId>
+      <optional>true</optional>
+    </dependency>
     <!-- test deps -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertor.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import java.util.Optional;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretUtils;
+import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential;
+import hudson.Extension;
+import io.fabric8.kubernetes.api.model.Secret;
+
+/**
+ * SecretToCredentialConvertor that converts {@link com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential}.
+ */
+@Extension
+public class VaultAppRoleCredentialsConvertor extends SecretToCredentialConverter {
+
+    @Override
+    public boolean canConvert(String type) {
+        return "vaultAppRole".equals(type);
+    }
+
+    @Override
+    public VaultAppRoleCredential convert(Secret secret) throws CredentialsConvertionException {
+        SecretUtils.requireNonNull(secret.getData(), "vaultAppRole definition contains no data");
+
+        String roleIdBase64 = SecretUtils.getNonNullSecretData(secret, "roleId", "vaultAppRole credential is missing the roleId");
+        String secretIdBase64 = SecretUtils.getNonNullSecretData(secret, "secretId", "vaultAppRole credential is missing the secretId");
+        Optional<String> pathBase64 = SecretUtils.getOptionalSecretData(secret, "path", "vaultAppRole credential is missing the path");
+        Optional<String> namespaceBase64 = SecretUtils.getOptionalSecretData(secret, "namespace", "vaultAppRole credential is missing the namespace");
+
+        String roleId = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(roleIdBase64), "vaultAppRole credential has an invalid roleId (must be base64 encoded UTF-8)");
+        String secretId = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(secretIdBase64), "vaultAppRole credential has an invalid secretId (must be base64 encoded UTF-8)");
+        String path = "approle";
+        if (pathBase64.isPresent()) {
+            path = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(pathBase64.get()), "vaultAppRole credential has an invalid path (must be base64 encoded UTF-8)");
+        }
+
+        VaultAppRoleCredential cred = new VaultAppRoleCredential(SecretUtils.getCredentialScope(secret),
+                SecretUtils.getCredentialId(secret),
+                SecretUtils.getCredentialDescription(secret),
+                roleId,
+                hudson.util.Secret.fromString(secretId),
+                path);
+
+        if (namespaceBase64.isPresent()) {
+            String namespace = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(namespaceBase64.get()), "vaultAppRole credential has an invalid namespace (must be base64 encoded UTF-8)");
+            cred.setNamespace(namespace);
+        }
+
+        return cred;
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertor.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import java.util.Optional;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretUtils;
+import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential;
+import com.datapipe.jenkins.vault.credentials.VaultGithubTokenCredential;
+import hudson.Extension;
+import io.fabric8.kubernetes.api.model.Secret;
+
+/**
+ * SecretToCredentialConvertor that converts {@link com.datapipe.jenkins.vault.credentials.VaultGithubTokenCredential}.
+ */
+@Extension
+public class VaultGitHubTokenCredentialsConvertor extends SecretToCredentialConverter {
+
+    @Override
+    public boolean canConvert(String type) {
+        return "vaultGitHubToken".equals(type);
+    }
+
+    @Override
+    public VaultGithubTokenCredential convert(Secret secret) throws CredentialsConvertionException {
+        SecretUtils.requireNonNull(secret.getData(), "vaultGitHubToken definition contains no data");
+
+        String accessTokenBase64 = SecretUtils.getNonNullSecretData(secret, "accessToken", "vaultGitHubToken credential is missing the accessToken");
+        Optional<String> mountPathBase64 = SecretUtils.getOptionalSecretData(secret, "mountPath", "vaultGitHubToken credential is missing the mountPath");
+        Optional<String> namespaceBase64 = SecretUtils.getOptionalSecretData(secret, "namespace", "vaultGitHubToken credential is missing the namespace");
+
+        String accessToken = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(accessTokenBase64), "vaultGitHubToken credential has an invalid accessToken (must be base64 encoded UTF-8)");
+
+        VaultGithubTokenCredential cred = new VaultGithubTokenCredential(SecretUtils.getCredentialScope(secret),
+                SecretUtils.getCredentialId(secret),
+                SecretUtils.getCredentialDescription(secret),
+                hudson.util.Secret.fromString(accessToken));
+
+        if (mountPathBase64.isPresent()) {
+            String mountPath = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(mountPathBase64.get()), "vaultGitHubToken credential has an invalid mountPath (must be base64 encoded UTF-8)");
+            cred.setMountPath(mountPath);
+        }
+
+        if (namespaceBase64.isPresent()) {
+            String namespace = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(namespaceBase64.get()), "vaultGitHubToken credential has an invalid namespace (must be base64 encoded UTF-8)");
+            cred.setNamespace(namespace);
+        }
+
+        return cred;
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertor.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretUtils;
+import com.datapipe.jenkins.vault.credentials.VaultTokenCredential;
+import hudson.Extension;
+import io.fabric8.kubernetes.api.model.Secret;
+
+/**
+ * SecretToCredentialConvertor that converts {@link com.datapipe.jenkins.vault.credentials.VaultTokenCredential}.
+ */
+@Extension
+public class VaultTokenCredentialsConvertor extends SecretToCredentialConverter {
+
+    @Override
+    public boolean canConvert(String type) {
+        return "vaultToken".equals(type);
+    }
+
+    @Override
+    public VaultTokenCredential convert(Secret secret) throws CredentialsConvertionException {
+        SecretUtils.requireNonNull(secret.getData(), "vaultToken definition contains no data");
+
+        String tokenBase64 = SecretUtils.getNonNullSecretData(secret, "token", "vaultToken credential is missing the token");
+
+        String token = SecretUtils.requireNonNull(SecretUtils.base64DecodeToString(tokenBase64), "vaultToken credential has an invalid token (must be base64 encoded UTF-8)");
+
+        return new VaultTokenCredential(SecretUtils.getCredentialScope(secret),
+                SecretUtils.getCredentialId(secret),
+                SecretUtils.getCredentialDescription(secret),
+                hudson.util.Secret.fromString(token));
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AbstractConverterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/AbstractConverterTest.java
@@ -1,0 +1,122 @@
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Abstract credentials converter test.
+ */
+public class AbstractConverterTest {
+
+    /**
+     * Test and validate secret with empty "data". Expects a "void.yaml" test resource.
+     * @param convertor converter to test
+     * @throws IOException if unable to load "void.yaml" test resource
+     */
+    protected final void testNoData(SecretToCredentialConverter convertor) throws IOException {
+        try {
+            Secret secret = getSecret("void.yaml");
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("contains no data"));
+        }
+    }
+
+    /**
+     * Test and validate missing field. Expects a test resource file named "missing<field>.yaml" where the {@code field}
+     * name is capitalized.
+     * @param convertor converter to test
+     * @param field field name
+     * @throws IOException if unable to load test resource
+     * @see #testMissingField(SecretToCredentialConverter, String, String)
+     */
+    protected final void testMissingField(SecretToCredentialConverter convertor, String field) throws IOException {
+        testMissingField(convertor, field, "missing" + StringUtils.capitalize(field) + ".yaml");
+    }
+
+    /**
+     * Test and validate missing field.
+     * @param convertor converter to test
+     * @param field field name
+     * @param resource test resource file name
+     * @throws IOException if unable to load test resource
+     */
+    protected final void testMissingField(SecretToCredentialConverter convertor, String field, String resource) throws IOException {
+        try {
+            Secret secret = getSecret(resource);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("missing the " + field));
+        }
+    }
+
+    /**
+     * Test and validate corrupt field. Expects a test resource file named "corrupt<field>.yaml" where the {@code field}
+     * name is capitalized.
+     * @param convertor converter to test
+     * @param field field name
+     * @throws IOException if unable to load test resource
+     * @see #testCorruptField(SecretToCredentialConverter, String, String)
+     */
+    protected final void testCorruptField(SecretToCredentialConverter convertor, String field) throws IOException {
+        testCorruptField(convertor, field, "corrupt" + StringUtils.capitalize(field) + ".yaml");
+    }
+
+    /**
+     * Test and validate corrupt field.
+     * @param convertor converter to test
+     * @param field field name
+     * @param resource test resource file name
+     * @throws IOException if unable to load test resource
+     */
+    protected final void testCorruptField(SecretToCredentialConverter convertor, String field, String resource) throws IOException {
+        try {
+            Secret secret = getSecret(resource);
+            convertor.convert(secret);
+            fail("Exception should have been thrown");
+        } catch (CredentialsConvertionException cex) {
+            assertThat(cex.getMessage(), containsString("invalid " + field));
+        }
+    }
+
+    /**
+     * Load kubernetes secret test resource file.
+     * @param resource resource file name
+     * @return kubernetes secret resource
+     * @throws IOException if unable to load test resource
+     */
+    protected final Secret getSecret(String resource) throws IOException {
+        try (InputStream is = getTestResource(resource)) {
+            return Serialization.unmarshal(is, Secret.class);
+        }
+    }
+
+    /**
+     * Get test resource as input stream. Resources are expected to be in a resource folder under
+     * {@code com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors} and with the same
+     * name as the test class.
+     * @param resource resource file name
+     * @return resource input stream
+     */
+    protected final InputStream getTestResource(String resource) {
+        String resourcePath = getClass().getSimpleName() + "/" + resource;
+        InputStream is = getClass().getResourceAsStream(resourcePath);
+        if (is == null) {
+            fail("failed to load resource " + resourcePath);
+        }
+
+        return is;
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/UsernamePasswordCredentialsConvertorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/UsernamePasswordCredentialsConvertorTest.java
@@ -73,7 +73,7 @@ public class UsernamePasswordCredentialsConvertorTest {
     public void canConvertAValidMappedSecret() throws Exception {
         UsernamePasswordCredentialsConvertor convertor = new UsernamePasswordCredentialsConvertor();
 
-        try (InputStream is = get("valid.yaml")) {
+        try (InputStream is = get("validMapped.yaml")) {
             Secret secret = Serialization.unmarshal(is, Secret.class);
             assertThat("The Secret was loaded correctly from disk", notNullValue());
             UsernamePasswordCredentialsImpl credential = convertor.convert(secret);

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential;
+import io.fabric8.kubernetes.api.model.Secret;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Tests {@link VaultAppRoleCredentialsConvertor}
+ */
+public class VaultAppRoleCredentialsConvertorTest extends AbstractConverterTest {
+
+    private VaultAppRoleCredentialsConvertor convertor;
+
+    @Before
+    public void setup() {
+        convertor = new VaultAppRoleCredentialsConvertor();
+    }
+
+    @Test
+    public void canConvert() throws Exception {
+        assertThat("correct registration of valid type", convertor.canConvert("vaultAppRole"), is(true));
+        assertThat("incorrect type is rejected", convertor.canConvert("something"), is(false));
+    }
+
+    @Test
+    public void canConvertAValidSecret() throws Exception {
+        Secret secret = getSecret("valid.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultAppRoleCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultapprole"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getRoleId(), is("myRoleId"));
+        assertThat("credential secretId is mapped correctly", credential.getSecretId().getPlainText(), is("-mySecretId-"));
+        assertThat("credential path is mapped correctly", credential.getPath(), is("approle"));
+        assertThat("credential namespace is mapped correctly", credential.getNamespace(), nullValue());
+    }
+
+    @Test
+    public void canConvertAValidSecretWithOptionalFields() throws Exception {
+        Secret secret = getSecret("validWithOptional.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultAppRoleCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultapprole"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getRoleId(), is("myRoleId"));
+        assertThat("credential secretId is mapped correctly", credential.getSecretId().getPlainText(), is("-mySecretId-"));
+        assertThat("credential path is mapped correctly", credential.getPath(), is("approle-jenkins"));
+        assertThat("credential namespace is mapped correctly", credential.getNamespace(), is("coolstuff"));
+    }
+
+    @Test
+    public void canConvertAValidMappedSecret() throws Exception {
+        Secret secret = getSecret("validMapped.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultAppRoleCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultapprole"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getRoleId(), is("myRoleId"));
+        assertThat("credential secretId is mapped correctly", credential.getSecretId().getPlainText(), is("-mySecretId-"));
+        assertThat("credential path is mapped correctly", credential.getPath(), is("approle-jenkins"));
+        assertThat("credential namespace is mapped correctly", credential.getNamespace(), is("coolstuff"));
+    }
+
+    @Issue("JENKINS-54313")
+    @Test
+    public void canConvertAValidSecretWithNoDescription() throws Exception {
+        Secret secret = getSecret("valid-no-desc.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultAppRoleCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultapprole"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is(emptyString()));
+    }
+
+    @Issue("JENKINS-53105")
+    @Test
+    public void canConvertAValidScopedSecret() throws Exception {
+        Secret secret = getSecret("validScoped.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultAppRoleCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultapprole"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.SYSTEM));
+    }
+
+    @Test
+    public void failsToConvertWhenRoleIdMissing() throws Exception {
+        testMissingField(convertor, "roleId");
+    }
+    
+    @Test
+    public void failsToConvertWhenSecredIdMissing() throws Exception {
+        testMissingField(convertor, "secretId");
+    }
+
+    @Test
+    public void failsToConvertWhenRoleIdCorrupt() throws Exception {
+        testCorruptField(convertor, "roleId");
+    }
+
+    @Test
+    public void failsToConvertWhenSecretIdCorrupt() throws Exception {
+        testCorruptField(convertor, "secretId");
+    }
+
+    @Test
+    public void failsToConvertWhenPathCorrupt() throws Exception {
+        testCorruptField(convertor, "path");
+    }
+
+    @Test
+    public void failsToConvertWhenNamespaceCorrupt() throws Exception {
+        testCorruptField(convertor, "namespace");
+    }
+
+    @Test
+    public void failsToConvertWhenDataEmpty() throws Exception {
+        testNoData(convertor);
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.credentials.VaultGithubTokenCredential;
+import io.fabric8.kubernetes.api.model.Secret;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Tests {@link VaultGitHubTokenCredentialsConvertor}
+ */
+public class VaultGitHubTokenCredentialsConvertorTest extends AbstractConverterTest {
+
+    private VaultGitHubTokenCredentialsConvertor convertor;
+
+    @Before
+    public void setup() {
+        convertor = new VaultGitHubTokenCredentialsConvertor();
+    }
+
+    @Test
+    public void canConvert() throws Exception {
+        assertThat("correct registration of valid type", convertor.canConvert("vaultGitHubToken"), is(true));
+        assertThat("incorrect type is rejected", convertor.canConvert("something"), is(false));
+    }
+
+    @Test
+    public void canConvertAValidSecret() throws Exception {
+        Secret secret = getSecret("valid.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultGithubTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultgithubtoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getAccessToken().getPlainText(), is("-myAccessToken-"));
+        assertThat("credential path is mapped correctly", credential.getMountPath(), is("github"));
+        assertThat("credential namespace is mapped correctly", credential.getNamespace(), nullValue());
+    }
+
+    @Test
+    public void canConvertAValidSecretWithOptionalFields() throws Exception {
+        Secret secret = getSecret("validWithOptional.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultGithubTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultgithubtoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getAccessToken().getPlainText(), is("-myAccessToken-"));
+        assertThat("credential path is mapped correctly", credential.getMountPath(), is("github-jenkins"));
+        assertThat("credential namespace is mapped correctly", credential.getNamespace(), is("coolstuff"));
+    }
+
+    @Test
+    public void canConvertAValidMappedSecret() throws Exception {
+        Secret secret = getSecret("validMapped.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultGithubTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultgithubtoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getAccessToken().getPlainText(), is("-myAccessToken-"));
+        assertThat("credential path is mapped correctly", credential.getMountPath(), is("github-jenkins"));
+        assertThat("credential namespace is mapped correctly", credential.getNamespace(), is("coolstuff"));
+    }
+
+    @Issue("JENKINS-54313")
+    @Test
+    public void canConvertAValidSecretWithNoDescription() throws Exception {
+        Secret secret = getSecret("valid-no-desc.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultGithubTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultgithubtoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is(emptyString()));
+    }
+
+    @Issue("JENKINS-53105")
+    @Test
+    public void canConvertAValidScopedSecret() throws Exception {
+        Secret secret = getSecret("validScoped.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultGithubTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaultgithubtoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.SYSTEM));
+    }
+
+    @Test
+    public void failsToConvertWhenAccessTokenMissing() throws Exception {
+        testMissingField(convertor, "accessToken");
+    }
+
+    @Test
+    public void failsToConvertWhenAccessTokenCorrupt() throws Exception {
+        testCorruptField(convertor, "accessToken");
+    }
+
+    @Test
+    public void failsToConvertWhenMountPathCorrupt() throws Exception {
+        testCorruptField(convertor, "mountPath");
+    }
+
+    @Test
+    public void failsToConvertWhenNamespaceCorrupt() throws Exception {
+        testCorruptField(convertor, "namespace");
+    }
+
+    @Test
+    public void failsToConvertWhenDataEmpty() throws Exception {
+        testNoData(convertor);
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.convertors;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.credentials.VaultTokenCredential;
+import io.fabric8.kubernetes.api.model.Secret;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Tests {@link VaultTokenCredentialsConvertor}
+ */
+public class VaultTokenCredentialsConvertorTest extends AbstractConverterTest {
+
+    private VaultTokenCredentialsConvertor convertor;
+
+    @Before
+    public void setup() {
+        convertor = new VaultTokenCredentialsConvertor();
+    }
+
+    @Test
+    public void canConvert() throws Exception {
+        assertThat("correct registration of valid type", convertor.canConvert("vaultToken"), is(true));
+        assertThat("incorrect type is rejected", convertor.canConvert("something"), is(false));
+    }
+
+    @Test
+    public void canConvertAValidSecret() throws Exception {
+        Secret secret = getSecret("valid.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaulttoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getToken().getPlainText(), is("-myToken-"));
+    }
+
+    @Test
+    public void canConvertAValidMappedSecret() throws Exception {
+        Secret secret = getSecret("validMapped.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaulttoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat("credential roleId is mapped correctly", credential.getToken().getPlainText(), is("-myToken-"));
+    }
+
+    @Issue("JENKINS-54313")
+    @Test
+    public void canConvertAValidSecretWithNoDescription() throws Exception {
+        Secret secret = getSecret("valid-no-desc.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaulttoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is(emptyString()));
+    }
+
+    @Issue("JENKINS-53105")
+    @Test
+    public void canConvertAValidScopedSecret() throws Exception {
+        Secret secret = getSecret("validScoped.yaml");
+        assertThat("The Secret was loaded correctly from disk", notNullValue());
+        VaultTokenCredential credential = convertor.convert(secret);
+        assertThat(credential, notNullValue());
+        assertThat("credential id is mapped correctly", credential.getId(), is("a-test-vaulttoken"));
+        assertThat("credential description is mapped correctly", credential.getDescription(), is("credentials from Kubernetes"));
+        assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.SYSTEM));
+    }
+
+    @Test
+    public void failsToConvertWhenTokenCorrupt() throws Exception {
+        testCorruptField(convertor, "token");
+    }
+
+    @Test
+    public void failsToConvertWhenDataEmpty() throws Exception {
+        testNoData(convertor);
+    }
+
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptNamespace.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptNamespace.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+    # so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+    # description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+  # UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+  namespace: hello            #not base64
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptPath.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptPath.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+    # so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+    # description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+  # UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+  path: hello                 #not base64

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptRoleId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptRoleId.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+    # so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+    # description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+  # UTF-8 base64 encoded
+  roleId: hello               #not base64
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptSecretId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/corruptSecretId.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+    # so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+    # description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+  # UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: hello             #not base64
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/missingRoleId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/missingRoleId.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/missingSecretId.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/missingSecretId.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/valid-no-desc.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/valid-no-desc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/valid.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/valid.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/validMapped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/validMapped.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+# map the roleId field to r
+    "jenkins.io/credentials-keybinding-roleId": "r"
+# map the secretId field to s
+    "jenkins.io/credentials-keybinding-secretId": "s"
+# map the path field to p
+    "jenkins.io/credentials-keybinding-path": "p"
+# map the namespace field to s
+    "jenkins.io/credentials-keybinding-namespace": "n"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  r: bXlSb2xlSWQ=          #myRoleId
+  s: LW15U2VjcmV0SWQt      #-mySecretId-
+  p: YXBwcm9sZS1qZW5raW5z  #approle-jenkins
+  n: Y29vbHN0dWZm          #coolstuff
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/validScoped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/validScoped.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+# set the scope (default global)
+    "jenkins.io/credentials-scope": "system"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/validWithOptional.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/validWithOptional.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  roleId: bXlSb2xlSWQ=        #myRoleId
+  secretId: LW15U2VjcmV0SWQt  #-mySecretId-
+  path: YXBwcm9sZS1qZW5raW5z  #approle-jenkins
+  namespace: Y29vbHN0dWZm     #coolstuff
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/void.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertorTest/void.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultapprole"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultAppRole"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/corruptAccessToken.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/corruptAccessToken.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: hello        #not base64
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/corruptMountPath.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/corruptMountPath.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: LW15QWNjZXNzVG9rZW4t        #-myAccessToken-
+  mountPath: hello                         #not base64

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/corruptNamespace.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/corruptNamespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: LW15QWNjZXNzVG9rZW4t        #-myAccessToken-
+  namespace: hello                         #not base64

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/missingAccessToken.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/missingAccessToken.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  mountPath: Z2l0aHViLWplbmtpbnM=          #github-jenkins

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/valid-no-desc.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/valid-no-desc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: LW15QWNjZXNzVG9rZW4t        #-myAccessToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/valid.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/valid.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: LW15QWNjZXNzVG9rZW4t        #-myAccessToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/validMapped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/validMapped.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+# map the accessToken field to a
+    "jenkins.io/credentials-keybinding-accessToken": "a"
+# map the mountPath field to m
+    "jenkins.io/credentials-keybinding-mountPath": "m"
+# map the namespace field to n
+    "jenkins.io/credentials-keybinding-namespace": "n"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  a: LW15QWNjZXNzVG9rZW4t          #-myAccessToken-
+  m: Z2l0aHViLWplbmtpbnM=          #github-jenkins
+  n: Y29vbHN0dWZm                  #coolstuff

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/validScoped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/validScoped.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+# set the scope (default global)
+    "jenkins.io/credentials-scope": "system"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: LW15QWNjZXNzVG9rZW4t        #-myAccessToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/validWithOptional.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/validWithOptional.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  accessToken: LW15QWNjZXNzVG9rZW4t        #-myAccessToken-
+  mountPath: Z2l0aHViLWplbmtpbnM=          #github-jenkins
+  namespace: Y29vbHN0dWZm                  #coolstuff

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/void.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertorTest/void.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaultgithubtoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultGitHubToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/corruptToken.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/corruptToken.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaulttoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  token: hello        #myToken
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/valid-no-desc.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/valid-no-desc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaulttoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  token: LW15VG9rZW4t        #-myToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/valid.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/valid.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaulttoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  token: LW15VG9rZW4t        #-myToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/validMapped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/validMapped.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaulttoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+# map the token field to t
+    "jenkins.io/credentials-keybinding-token": "t"
+type: Opaque
+data:
+# UTF-8 base64 encoded
+  t: LW15VG9rZW4t        #-myToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/validScoped.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/validScoped.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaulttoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+# set the scope (default global)
+    "jenkins.io/credentials-scope": "system"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+  # UTF-8 base64 encoded
+  token: LW15VG9rZW4t        #-myToken-
+

--- a/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/void.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertorTest/void.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-vaulttoken"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "vaultToken"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+data:
+


### PR DESCRIPTION
This add support for VaultCredential types from jenkinsci/hashicorp-vault-plugin
- VaultAppRoleCredential
- VaultGitHubTokenCredential
- VaultTokenCredential

The following types are explicitly not supported because the don't require secret data:
- VaultTokenFileCredential
- VaultKubernetesCredential
- VaultGCPCredential

Refs: JENKINS-68327

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
