### PR TITLE
use the correct name of Hashicorp Vault plugin

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultAppRoleCredentialsConvertor.java
@@ -35,7 +35,7 @@ import org.jenkinsci.plugins.variant.OptionalExtension;
 /**
  * SecretToCredentialConvertor that converts {@link com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential}.
  */
-@OptionalExtension(requirePlugins={"hashicorp-vault"})
+@OptionalExtension(requirePlugins={"hashicorp-vault-plugin"})
 public class VaultAppRoleCredentialsConvertor extends SecretToCredentialConverter {
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultGitHubTokenCredentialsConvertor.java
@@ -35,7 +35,7 @@ import org.jenkinsci.plugins.variant.OptionalExtension;
 /**
  * SecretToCredentialConvertor that converts {@link com.datapipe.jenkins.vault.credentials.VaultGithubTokenCredential}.
  */
-@OptionalExtension(requirePlugins={"hashicorp-vault"})
+@OptionalExtension(requirePlugins={"hashicorp-vault-plugin"})
 public class VaultGitHubTokenCredentialsConvertor extends SecretToCredentialConverter {
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/VaultTokenCredentialsConvertor.java
@@ -34,7 +34,7 @@ import org.jenkinsci.plugins.variant.OptionalExtension;
 /**
  * SecretToCredentialConvertor that converts {@link com.datapipe.jenkins.vault.credentials.VaultTokenCredential}.
  */
-@OptionalExtension(requirePlugins={"hashicorp-vault"})
+@OptionalExtension(requirePlugins={"hashicorp-vault-plugin"})
 public class VaultTokenCredentialsConvertor extends SecretToCredentialConverter {
 
     @Override


### PR DESCRIPTION
This fixes the name of the Hashicorp Vault plugin that enables the new credential types introduced with PR #59.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
