### PR TITLE
[JENKINS-69927] Display only one monitor instead of duplicates when i…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -136,11 +136,15 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
             if (reconnectClientOnException) {
                 reconnectLater();
             }
+            // Only report the latest failure
+            clearAdminMonitors(initAdminMonitorId);
             new AdministrativeError(initAdminMonitorId,
                     "Failed to initialize Kubernetes secret provider",
                     "Credentials from Kubernetes Secrets will not be available.", kex);
         } catch (LabelSelectorParseException lex) {
             LOG.log(Level.SEVERE, "Failed to initialise k8s secret provider, secrets from Kubernetes will not be available", lex);
+            // Only report the latest failure
+            clearAdminMonitors(labelSelectorAdminMonitorId);
             new AdministrativeError(labelSelectorAdminMonitorId,
                     "Failed to parse Kubernetes secret label selector",
                     "Failed to parse Kubernetes secret <a href=\"https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors\" _target=\"blank\">label selector</a> " +

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
@@ -121,6 +121,8 @@ public class KubernetesCredentialsProviderTest {
         KubernetesCredentialProvider provider = new MockedKubernetesCredentialProvider();
         provider.startWatchingForSecrets();
         assertEquals("expect administrative error", 1, getInitAdministrativeMonitorCount());
+        provider.startWatchingForSecrets();
+        assertEquals("expect at most 1 administrative error", 1, getInitAdministrativeMonitorCount());
 
         // enable default responses
         defaultMockKubernetesResponses();

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
@@ -130,7 +130,7 @@ public class KubernetesCredentialsProviderTest {
         provider.startWatchingForSecrets();
         // verify we schedule reconnect task
         ArgumentCaptor<Runnable> reconnectTask = ArgumentCaptor.forClass(Runnable.class);
-        verify(jenkinsTimer).schedule(reconnectTask.capture(), eq(5L), eq(TimeUnit.MINUTES));
+        verify(jenkinsTimer, times(2)).schedule(reconnectTask.capture(), eq(5L), eq(TimeUnit.MINUTES));
         reconnectTask.getValue().run();
         assertEquals("expect administrative error to be cleared", 0, getInitAdministrativeMonitorCount());
     }


### PR DESCRIPTION
…nitializing watcher

[JENKINS-69927](https://issues.jenkins.io/browse/JENKINS-69927)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue