### PR TITLE
Compatibility with kubernetes-client 6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.39</version>
+    <version>4.50</version>
     <relativePath />
   </parent>
 
@@ -45,8 +45,8 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.303.3</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.332.4</jenkins.version>
+    <bom>2.332.x</bom>
     <junit5.version>5.7.2</junit5.version>
   </properties>
 
@@ -78,59 +78,21 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>symbol-annotation</artifactId>
-        <version>1.22</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>trilead-ssh2</artifactId>
-        <version>build-217-jenkins-16</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>credentials</artifactId>
-        <version>2.3.15</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>credentials-binding</artifactId>
-        <version>1.24</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>structs</artifactId>
-        <version>1.22</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-step-api</artifactId>
-        <version>2.23</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plain-credentials</artifactId>
-        <version>1.7</version>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${bom}</artifactId>
+        <version>1706.vc166d5f429f8</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>aws-credentials</artifactId>
-        <version>1.26</version>
+        <version>1.33</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>docker-commons</artifactId>
         <version>1.16</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkinsci.plugins</groupId>
-        <artifactId>pipeline-model-extensions</artifactId>
-        <version>1.3.8</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>scm-api</artifactId>
-        <version>2.2.6</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -149,16 +111,6 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>ssh-credentials</artifactId>
-        <version>1.18.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>variant</artifactId>
-        <version>1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>github-branch-source</artifactId>
         <version>2.7.1</version>
       </dependency>
@@ -168,30 +120,9 @@
         <version>3.8.0</version>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jquery-detached</artifactId>
         <version>1.2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>jackson2-api</artifactId>
-        <version>2.13.0-230.v59243c64b0a5</version>
-
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.9</version>
-      </dependency>
-      <dependency>
-        <groupId>com.infradna.tool</groupId>
-        <artifactId>bridge-method-annotation</artifactId>
-        <version>1.21</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -200,7 +131,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>5.12.1-187.v577c3e368fb_6</version>
+      <version>6.3.1-205.vea_a_fc21de909</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -283,7 +214,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
-      <version>5.12.1</version>
+      <version>6.3.1</version>
       <scope>test</scope>
       <exclusions>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>6.3.1-205.vea_a_fc21de909</version>
+      <version>6.3.1-206.v76d3b_6b_14db_b</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -23,6 +23,7 @@
  */
 package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider;
 
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.WatcherException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +43,6 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
@@ -94,7 +94,7 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
         if (client == null) {
             ConfigBuilder cb = new ConfigBuilder();
             Config config = cb.build();
-            client = new DefaultKubernetesClient(config);
+            client = new KubernetesClientBuilder().withConfig(config).build();
         }
         return client;
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtilsTest.java
@@ -189,7 +189,7 @@ public class SecretUtilsTest {
             SecretUtils.getNonNullSecretData(s, "some-key", "oops");
             fail();
         } catch (CredentialsConvertionException cce) {
-            assertThat(cce.getMessage(), is("oops"));
+            assertThat(cce.getMessage(), is("oops (mapped to some-key)"));
         } 
     }
 


### PR DESCRIPTION
Main compatibility has been fixed through https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/pull/73, this is making the plugin depend on kubernetes-client 6.x at compile time and allows additional cleanup.

* Jenkins 2.332.4
* Use Jenkins BOM
* Kubernetes-client-api 6.x

Downstream of https://github.com/jenkinsci/kubernetes-client-api-plugin/pull/163

I initially thought this plugin was compatible with the new kubernetes-client version. I missed the fact their `KubernetesClient` builder is now unusable out of the box in Jenkins context as it assumes context class loader = calling class classloader, which is not the case in the context of Jenkins classloading.

The main fix is very simple but unfortunately needs to be applied.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
