### PR TITLE
Added jenkins.io/credentials-id annotation

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtils.java
@@ -55,6 +55,9 @@ public abstract class SecretUtils {
     /** Optional Kubernetes annotation for the credential description */
     private static final String JENKINS_IO_CREDENTIALS_DESCRIPTION_ANNOTATION = "jenkins.io/credentials-description";
 
+    /** Optional Kubernetes annotation for the credential id */
+    private static final String JENKINS_IO_CREDENTIALS_ID_ANNOTATION = "jenkins.io/credentials-id";
+
     /** Annotation prefix for the optional custom mapping of data */
     private static final String JENKINS_IO_CREDENTIALS_KEYBINDING_ANNOTATION_PREFIX = "jenkins.io/credentials-keybinding-";
 
@@ -129,6 +132,10 @@ public abstract class SecretUtils {
      */
     public static String getCredentialId(Secret s) {
         // we must have a metadata as the label that identifies this as a Jenkins credential needs to be present
+        Map<String, String> annotations = s.getMetadata().getAnnotations();
+        if (annotations != null && annotations.get(JENKINS_IO_CREDENTIALS_ID_ANNOTATION) != null) {
+            return annotations.get(JENKINS_IO_CREDENTIALS_ID_ANNOTATION);
+        }
         return s.getMetadata().getName();
     }
 


### PR DESCRIPTION
This PR is to add the `jenkins.io/credentials-id` annotation to have the possibility to set a Jenkins credentials ID without being obliged to respect the Kubernetes Object Names constraints (defined in [RFC 1123](https://tools.ietf.org/html/rfc1123) and [RFC 1123](https://tools.ietf.org/html/rfc1123)):
- contain no more than 253 characters
- contain only lowercase alphanumeric characters, '-' or '.'
- start with an alphanumeric character
- end with an alphanumeric character

Adding this `jenkins.io/credentials-id` annotation to the secret, the user can use a Jenkins credentials ID with a more relaxed name constraint:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: "my-test-secret"
  labels:
    "jenkins.io/credentials-type": "usernamePassword"
  annotations:
    "jenkins.io/credentials-description": "My test Jenkins credential description"
    "jenkins.io/credentials-id": "my_test_jenkins_cred_id"
    
type: Opaque
stringData:
  username: myUsername
  password: 'Pa$$word'
```
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
