### PR TITLE
fix(docs): correct rendering of the plugin README on plugins.jenkins.io

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Because granting these permissions for secrets is not something that should be d
 
 ### Adding credentials
 
-Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/examples/](examples) page.
+Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [examples](./examples) page.
 
 To restrict the secrets added by this plugin use the system property `com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector`
 to set the [Kubernetes Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) expression.
@@ -83,4 +83,4 @@ The latest release will be visible in the Jenkins Update center approximatly 8 h
 
 # Developing
 
-This [page](dev/) contains more information on a developer environment.
+This [page](./dev/) contains more information on a developer environment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Because granting these permissions for secrets is not something that should be d
 
 ### Adding credentials
 
-Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [examples](examples) page.
+Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/examples/](examples) page.
 
 To restrict the secrets added by this plugin use the system property `com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector`
 to set the [Kubernetes Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) expression.

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
   <name>Kubernetes Credentials Provider</name>
   <description>Provides a credentials store backed by Kubernetes.</description>
-  <url>https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/blob/master/docs/README.md</url>
+  <url>https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/</url>
 
   <inceptionYear>2018</inceptionYear>
 


### PR DESCRIPTION
This PR replaces the relative `examples` link by an absolute one, to avoid a 404 error when clicking on this link from the plugin description page on plugins.jenkins.io.

On https://plugins.jenkins.io/kubernetes-credentials-provider/ `examples` currently links to https://plugins.jenkins.io/kubernetes-credentials-provider/examples (not found)

Closes https://github.com/jenkins-infra/plugin-site/issues/1519

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
