### PR TITLE
fix(docs): proper (distinct) README for plugins.jenkins.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/kubernetes-credentials-provider.svg?color=blue)](https://plugins.jenkins.io/kubernetes-credentials-provider)
 
 
-The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retreival of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
+The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retrieval of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/kubernetes-credentials-provider.svg?color=blue)](https://plugins.jenkins.io/kubernetes-credentials-provider)
 
 
-The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retrieval of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
+The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retrieval of [Credentials](https://plugins.jenkins.io/credentials) stored as [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin 
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 
-The complete documentation is available on [this GitHub page ](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
+The full documentation is available on [this GitHub page](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
 
 ## Releases and Changelogs
 

--- a/README.md
+++ b/README.md
@@ -14,4 +14,3 @@ The full documentation is available on [this GitHub page](https://jenkinsci.gith
 ## Releases and Changelogs
 
 The [release notes](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/releases) are managed in GitHub. 
-The latest release will be visible in the Jenkins Update center approximatly 8 hours after a release.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The plugin supports most common credential types and defines an [`extension poin
 
 The complete documentation is available on [this GitHub page ](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
 
-# Releases and Change logs
+## Releases and Changelogs
 
 The [release notes](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/releases) are managed in GitHub. 
 The latest release will be visible in the Jenkins Update center approximatly 8 hours after a release.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,103 @@
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/kubernetes-credentials-provider-plugin.svg?label=release)](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/releases/latest)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/kubernetes-credentials-provider.svg?color=blue)](https://plugins.jenkins.io/kubernetes-credentials-provider)
 
-Jenkins credentials provider for Kubernetes
+Complete documentation on GitHub page is [here](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
 
-Documentation is [here](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
+The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retreival of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
+
+The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
+
+# Using
+
+### Pre-requisites
+
+- Jenkins must be running in a kubernetes cluster
+- The pod running Jenkins must have a service account with a role that sets the following:
+  - get/watch/list permissions for `secrets` [¹](#footnotes)
+
+
+Because granting these permissions for secrets is not something that should be done lightly it is highly advised for security reasons that you both create a unique service account to run Jenkins as, and run Jenkins in a unique namespace.
+
+## Managing credentials
+
+### Adding credentials
+
+Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [examples](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/examples) page.
+
+To restrict the secrets added by this plugin use the system property `com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector`
+to set the [Kubernetes Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) expression.
+
+```
+-Dcom.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector="env in (iat uat)"
+```
+
+### Updating credentials
+
+Credentials are updated automatically when changes are made to the Kubernetes secret.
+
+### Deleting credentials
+
+Credentials are deleted automatically when the secret is deleted from Kubernetes. 
+
+### Viewing credentials
+
+Once added the credentials will be visible in Jenkins under the `/credentials/` page.
+Any credentials that are loaded from Kubernetes can be identified by the Kubernetes provider icon in the view.
+
+## Using the credentials inside Jenkins
+
+To use credentials in a pipeline you do not need to do anything special, you access them just as you would for credentials stored in Jenkins. 
+
+for example, if you had the follwing Secret defined in Kubernetes:
+<!-- docs/examples/username-pass.yaml -->
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "another-test-usernamepass"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "usernamePassword"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "credentials from Kubernetes"
+type: Opaque
+stringData:
+  username: myUsername
+  password: 'Pa$$word'
+```
+
+you could use it via the [Credentials Binding plugin](https://plugins.jenkins.io/credentials-binding) 
+
+```groovy
+withCredentials([usernamePassword(credentialsId: 'another-test-usernamepass',
+                                  usernameVariable: 'USER', 
+                                  passwordVariable: 'PASS')]) {
+  sh 'curl -u $USER:$PASS https://some-api/'
+}
+```
+
+or by passing the credentialId directly to the step requiring a credential:
+
+```groovy
+git credentialsId: 'another-test-usernamepass', url: 'https://github.com/foo/bar'
+```
+
+# Issue reporting
+
+Any issues should be reporting in the main [Jenkins JIRA tracker](https://issues.jenkins-ci.org).
+The issue tracker is not a help forum, for help please use [IRC](https://jenkins.io/chat/) or the [user mailing list](https://groups.google.com/forum/#!forum/jenkinsci-users) 
+
+# Releases and Change logs
+
+The [release notes](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/releases) are managed in GitHub. 
+The latest release will be visible in the Jenkins Update center approximatly 8 hours after a release.
+
+# Developing
+
+This [page](./docs/dev/) contains more information on a developer environment.
+
+# Footnotes
+
+1: it is reported that running in KOPS on AWS you will also need permissions to get/watch/list `configmaps`

--- a/README.md
+++ b/README.md
@@ -4,103 +4,14 @@
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/kubernetes-credentials-provider-plugin.svg?label=release)](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/releases/latest)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/kubernetes-credentials-provider.svg?color=blue)](https://plugins.jenkins.io/kubernetes-credentials-provider)
 
-Complete documentation on GitHub page is [here](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
 
 The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retreival of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 
-# Using
-
-### Pre-requisites
-
-- Jenkins must be running in a kubernetes cluster
-- The pod running Jenkins must have a service account with a role that sets the following:
-  - get/watch/list permissions for `secrets` [¹](#footnotes)
-
-
-Because granting these permissions for secrets is not something that should be done lightly it is highly advised for security reasons that you both create a unique service account to run Jenkins as, and run Jenkins in a unique namespace.
-
-## Managing credentials
-
-### Adding credentials
-
-Credentials are added by adding them as secrets to Kubernetes, this is covered in more detail in the [examples](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/examples) page.
-
-To restrict the secrets added by this plugin use the system property `com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector`
-to set the [Kubernetes Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) expression.
-
-```
--Dcom.cloudbees.jenkins.plugins.kubernetes_credentials_provider.KubernetesCredentialProvider.labelSelector="env in (iat uat)"
-```
-
-### Updating credentials
-
-Credentials are updated automatically when changes are made to the Kubernetes secret.
-
-### Deleting credentials
-
-Credentials are deleted automatically when the secret is deleted from Kubernetes. 
-
-### Viewing credentials
-
-Once added the credentials will be visible in Jenkins under the `/credentials/` page.
-Any credentials that are loaded from Kubernetes can be identified by the Kubernetes provider icon in the view.
-
-## Using the credentials inside Jenkins
-
-To use credentials in a pipeline you do not need to do anything special, you access them just as you would for credentials stored in Jenkins. 
-
-for example, if you had the follwing Secret defined in Kubernetes:
-<!-- docs/examples/username-pass.yaml -->
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-# this is the jenkins id.
-  name: "another-test-usernamepass"
-  labels:
-# so we know what type it is.
-    "jenkins.io/credentials-type": "usernamePassword"
-  annotations:
-# description - can not be a label as spaces are not allowed
-    "jenkins.io/credentials-description" : "credentials from Kubernetes"
-type: Opaque
-stringData:
-  username: myUsername
-  password: 'Pa$$word'
-```
-
-you could use it via the [Credentials Binding plugin](https://plugins.jenkins.io/credentials-binding) 
-
-```groovy
-withCredentials([usernamePassword(credentialsId: 'another-test-usernamepass',
-                                  usernameVariable: 'USER', 
-                                  passwordVariable: 'PASS')]) {
-  sh 'curl -u $USER:$PASS https://some-api/'
-}
-```
-
-or by passing the credentialId directly to the step requiring a credential:
-
-```groovy
-git credentialsId: 'another-test-usernamepass', url: 'https://github.com/foo/bar'
-```
-
-# Issue reporting
-
-Any issues should be reporting in the main [Jenkins JIRA tracker](https://issues.jenkins-ci.org).
-The issue tracker is not a help forum, for help please use [IRC](https://jenkins.io/chat/) or the [user mailing list](https://groups.google.com/forum/#!forum/jenkinsci-users) 
+The complete documentation is available on [this GitHub page ](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
 
 # Releases and Change logs
 
 The [release notes](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/releases) are managed in GitHub. 
 The latest release will be visible in the Jenkins Update center approximatly 8 hours after a release.
-
-# Developing
-
-This [page](./docs/dev/) contains more information on a developer environment.
-
-# Footnotes
-
-1: it is reported that running in KOPS on AWS you will also need permissions to get/watch/list `configmaps`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin 
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 
-The full documentation is available on [this GitHub page](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/)
+The full documentation is available on [this GitHub page](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/).
 
 ## Releases and Changelogs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ title:  "Kubernetes Credentials Provider Plugin"
 permalink: /
 ---
 
-The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retrieval of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
+The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retrieval of [Credentials](https://plugins.jenkins.io/credentials) stored as [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ title:  "Kubernetes Credentials Provider Plugin"
 permalink: /
 ---
 
-The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retreival of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
+The *Kubernetes Credentials Provider* is a [Jenkins](https://jenkins.io) plugin to enable the retrieval of [Credentials](https://plugins.jenkins.io/credentials) directly from Kubernetes.
 
 The plugin supports most common credential types and defines an [`extension point`](https://jenkins.io/doc/developer/extensions/kubernetes-credentials-provider/) that can be implemented by other plugins to add support for custom Credential types. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.73</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
 
@@ -38,23 +38,22 @@
 
   <name>Kubernetes Credentials Provider</name>
   <description>Provides a credentials store backed by Kubernetes.</description>
-  <url>https://github.com/${gitHubRepo}</url>
+  <url>https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/</url>
 
   <inceptionYear>2018</inceptionYear>
 
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <gitHubRepo>jenkinsci/kubernetes-credentials-provider-plugin</gitHubRepo>
     <jenkins.version>2.414.1</jenkins.version>
     <bom>2.414.x</bom>
-    <junit5.version>5.7.2</junit5.version>
+    <junit5.version>5.10.0</junit5.version>
   </properties>
 
   <scm>
-    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
+    <connection>scm:git:https://github.com/jenkinsci/kubernetes-credentials-provider-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/kubernetes-credentials-provider-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/kubernetes-credentials-provider-plugin</url>
     <tag>${scmTag}</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,22 +38,23 @@
 
   <name>Kubernetes Credentials Provider</name>
   <description>Provides a credentials store backed by Kubernetes.</description>
-  <url>https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/</url>
+  <url>https://github.com/${gitHubRepo}</url>
 
   <inceptionYear>2018</inceptionYear>
 
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/kubernetes-credentials-provider-plugin</gitHubRepo>
     <jenkins.version>2.414.1</jenkins.version>
     <bom>2.414.x</bom>
     <junit5.version>5.7.2</junit5.version>
   </properties>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/kubernetes-credentials-provider-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/kubernetes-credentials-provider-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/kubernetes-credentials-provider-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.74</version>
+    <version>4.73</version>
     <relativePath />
   </parent>
 
@@ -47,7 +47,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.414.1</jenkins.version>
     <bom>2.414.x</bom>
-    <junit5.version>5.10.0</junit5.version>
+    <junit5.version>5.7.2</junit5.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
This PR completes the README at the root of the repo ~~with the updated content from docs/README.md~~, as using the GitHub page as plugin URL doesn't resolve the displaying issues of https://plugins.jenkins.io/kubernetes-credentials-provider/ (header table displayed, macros raw displayed).

Follow-up of #79 

Related: https://github.com/jenkins-infra/plugin-site/issues/1519

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
