### PR TITLE
Support scoping of credentials to lists of ItemGroups

### DIFF
--- a/docs/examples/username-pass.yaml
+++ b/docs/examples/username-pass.yaml
@@ -9,8 +9,8 @@ metadata:
   annotations:
 # description - can not be a label as spaces are not allowed
     "jenkins.io/credentials-description" : "credentials from Kubernetes"
-# job/folder scope - optional - individual items must begin and end with '/'
-    jenkins.io/credentials-item-group: ["/job/thisIsJobA/", "/job/thisIsJobB/job/nestedJob/"]
+# folder/job scope - optional
+    jenkins.io/credentials-store-locations: "['thisIsJobA', 'thisIsJobB', 'thisIsFolderA/thisIsJobC']"
 type: Opaque
 stringData:
   username: myUsername

--- a/docs/examples/username-pass.yaml
+++ b/docs/examples/username-pass.yaml
@@ -9,6 +9,8 @@ metadata:
   annotations:
 # description - can not be a label as spaces are not allowed
     "jenkins.io/credentials-description" : "credentials from Kubernetes"
+# job/folder scope - optional - individual items must begin and end with '/'
+    jenkins.io/credentials-item-group: ["/job/thisIsJobA/", "/job/thisIsJobB/job/nestedJob/"]
 type: Opaque
 stringData:
   username: myUsername

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -48,6 +48,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 import org.acegisecurity.Authentication;
 import org.kohsuke.accmod.Restricted;
@@ -60,12 +61,10 @@ import hudson.init.Terminator;
 import hudson.model.ItemGroup;
 import hudson.model.ModelObject;
 import hudson.security.ACL;
-import jenkins.model.Jenkins;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
-import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 
 @Extension
@@ -73,8 +72,8 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
 
     private static final Logger LOG = Logger.getLogger(KubernetesCredentialProvider.class.getName());
 
-    /** Map of Credentials keyed by their credential ID */
-    private ConcurrentHashMap<String, IdCredentials> credentials = new ConcurrentHashMap<>();
+    /** Map of {@link KubernetesSourcedCredential} keyed by their credential ID */
+    private ConcurrentHashMap<String, KubernetesSourcedCredential> credentials = new ConcurrentHashMap<>();
 
     @CheckForNull
     private KubernetesClient client;
@@ -85,7 +84,8 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
     /** Delay in minutes before attempting to reconnect k8s client */
     private int reconnectClientDelayMins = Integer.getInteger(KubernetesCredentialProvider.class.getName() + ".reconnectClientDelayMins", 5);
 
-    private KubernetesCredentialsStore store = new KubernetesCredentialsStore(this);
+    /** A map storing credential scores scoped to ModelObjects, each ModelObject has its own credential store */
+    private final Map<ModelObject, KubernetesCredentialsStore> lazyStoreCache = new HashMap<>();
 
     /**
      * Kubernetes <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">label selector</a> expression
@@ -120,7 +120,7 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
             // load current set of secrets into provider
             LOG.log(Level.FINER, "retrieving secrets");
             SecretList list = _client.secrets().withLabelSelector(selector).withLabel(SecretUtils.JENKINS_IO_CREDENTIALS_TYPE_LABEL).list();
-            ConcurrentHashMap<String, IdCredentials> _credentials = new  ConcurrentHashMap<>();
+            ConcurrentHashMap<String, KubernetesSourcedCredential> _credentials = new  ConcurrentHashMap<>();
             List<Secret> secretList = list.getItems();
             for (Secret s : secretList) {
                 LOG.log(Level.FINE, "Secret Added - {0}", SecretUtils.getCredentialId(s));
@@ -195,18 +195,32 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
 
     @Override
     public <C extends Credentials> List<C> getCredentials(Class<C> type, ItemGroup itemGroup, Authentication authentication) {
-        LOG.log(Level.FINEST, "getCredentials called with type {0} and authentication {1}", new Object[] {type.getName(), authentication});
+        LOG.log(Level.FINEST, "getCredentials called with type {0}, itemgroup {1} and authentication {2}", new Object[] {type.getName(), itemGroup, authentication});
         if (ACL.SYSTEM.equals(authentication)) {
             ArrayList<C> list = new ArrayList<>();
-            for (IdCredentials credential : credentials.values()) {
+            for (KubernetesSourcedCredential credential : credentials.values()) {
+                // Parent group of item can be null
+                if(itemGroup == null && !credential.getItemGroups().isEmpty()) {
+                    continue;
+                }
+                if(itemGroup != null) {
+                    String itemGroupPath = '/' + itemGroup.getUrl();
+                    Collection<String> itemGroups = credential.getItemGroups();
+                    LOG.log(Level.FINEST, "getCredentials checking if itemGroupPath {0} is in itemGroups of {1} ({2})", new Object[] { itemGroupPath, credential.getId(), itemGroups });
+                    if (!itemGroups.isEmpty() && itemGroups.stream().noneMatch(itemGroupPath::startsWith)) {
+                        LOG.log(Level.FINEST, "getCredentials itemGroupPath not found in: {0}", itemGroups);
+                        continue;
+                    }
+                }
+
                 // is s a type of type then populate the list...
                 LOG.log(Level.FINEST, "getCredentials {0} is a possible candidate", credential.getId());
                 if (CredentialsScope.SYSTEM == credential.getScope() && !(itemGroup instanceof Jenkins)) {
                     LOG.log(Level.FINEST, "getCredentials {0} has SYSTEM scope, but the context is not Jenkins, ignoring", credential.getId());
-                } else if (type.isAssignableFrom(credential.getClass())) {
+                } else if (type.isAssignableFrom(credential.getIdCredentials().getClass())) {
                     LOG.log(Level.FINEST, "getCredentials {0} matches, adding to list", credential.getId());
                     // cast to keep generics happy even though we are assignable..
-                    list.add(type.cast(credential));
+                    list.add(type.cast(credential.getIdCredentials()));
                 } else {
                     LOG.log(Level.FINEST, "getCredentials {0} does not match", credential.getId());
                 }
@@ -221,9 +235,7 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
     public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
                                                           @NonNull Item item,
                                                           Authentication authentication) {
-        // we do not support scoping to Items, so we just need to use null to not expose SYSTEM credentials to Items.
-        Objects.requireNonNull(item);
-        return getCredentials(type, (ItemGroup)null, authentication);
+        return getCredentials(type, item.getParent(), authentication);
     }
 
     @Override
@@ -245,10 +257,11 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
         addSecret(secret, credentials);
     }
 
-    private void addSecret(Secret secret, Map<String, IdCredentials> map) {
-        IdCredentials cred = convertSecret(secret);
+    private void addSecret(Secret secret, Map<String, KubernetesSourcedCredential> map) {
+        KubernetesSourcedCredential cred = convertSecret(secret);
+        String credentialId = SecretUtils.getCredentialId(secret);
         if (cred != null) {
-            map.put(SecretUtils.getCredentialId(secret), cred);
+            map.put(credentialId, cred);
         }
     }
 
@@ -296,13 +309,16 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
 
 
     @CheckForNull
-    IdCredentials convertSecret(Secret s) {
+    KubernetesSourcedCredential convertSecret(Secret s) {
         String type = s.getMetadata().getLabels().get(SecretUtils.JENKINS_IO_CREDENTIALS_TYPE_LABEL);
 
         SecretToCredentialConverter lookup = SecretToCredentialConverter.lookup(type);
         if (lookup != null) {
             try {
-                return lookup.convert(s);
+                return new KubernetesSourcedCredential(
+                        lookup.convert(s),
+                        SecretUtils.getCredentialItemScopes(s)
+                );
             } catch (CredentialsConvertionException ex) {
                 // do not spam the logs with the stacktrace...
                 if (LOG.isLoggable(Level.FINE)) {
@@ -320,7 +336,11 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
 
     @Override
     public CredentialsStore getStore(ModelObject object) {
-        return object == Jenkins.getInstance() ? store : null;
+        if(object instanceof ItemGroup<?>) {
+            lazyStoreCache.putIfAbsent(object, new KubernetesCredentialsStore(this, (ItemGroup<?>) object));
+            return lazyStoreCache.get(object);
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialProvider.java
@@ -204,10 +204,10 @@ public class KubernetesCredentialProvider extends CredentialsProvider implements
                     continue;
                 }
                 if(itemGroup != null) {
-                    String itemGroupPath = '/' + itemGroup.getUrl();
+                    String itemGroupPath = itemGroup.getFullName();
                     Collection<String> itemGroups = credential.getItemGroups();
                     LOG.log(Level.FINEST, "getCredentials checking if itemGroupPath {0} is in itemGroups of {1} ({2})", new Object[] { itemGroupPath, credential.getId(), itemGroups });
-                    if (!itemGroups.isEmpty() && itemGroups.stream().noneMatch(itemGroupPath::startsWith)) {
+                    if (!itemGroups.isEmpty() && itemGroups.stream().noneMatch(itemGroupPath::equals)) {
                         LOG.log(Level.FINEST, "getCredentials itemGroupPath not found in: {0}", itemGroups);
                         continue;
                     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsStore.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsStore.java
@@ -9,6 +9,7 @@ import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.jenkins.ui.icon.IconType;
 import org.kohsuke.stapler.export.ExportedBean;
+import hudson.model.ItemGroup;
 import hudson.model.ModelObject;
 import hudson.security.ACL;
 import hudson.security.Permission;
@@ -23,16 +24,18 @@ public class KubernetesCredentialsStore extends CredentialsStore {
 
     private final KubernetesCredentialProvider provider;
     private final KubernetesCredentialsStoreAction action = new KubernetesCredentialsStoreAction(this);
+    private final ItemGroup<?> context;
 
-    public KubernetesCredentialsStore(KubernetesCredentialProvider provider) {
+    public KubernetesCredentialsStore(KubernetesCredentialProvider provider, ItemGroup<?> context) {
         super(KubernetesCredentialProvider.class);
         this.provider = provider;
+        this.context = context;
     }
 
     @NonNull
     @Override
     public ModelObject getContext() {
-        return Jenkins.getInstance();
+        return context;
     }
 
     @Override
@@ -44,9 +47,9 @@ public class KubernetesCredentialsStore extends CredentialsStore {
     @NonNull
     @Override
     public List<Credentials> getCredentials(@NonNull Domain domain) {
-        // Only the global domain is supported
-        if (Domain.global().equals(domain) && Jenkins.getInstance().hasPermission(CredentialsProvider.VIEW))
-            return provider.getCredentials(Credentials.class, Jenkins.getInstance(), ACL.SYSTEM);
+        if(Jenkins.getInstance().hasPermission(CredentialsProvider.VIEW)) {
+                return provider.getCredentials(Credentials.class, context, ACL.SYSTEM);
+        }
         return Collections.emptyList();
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesSourcedCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesSourcedCredential.java
@@ -1,0 +1,41 @@
+package com.cloudbees.jenkins.plugins.kubernetes_credentials_provider;
+
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+
+/**
+ * Stores a credential that was sourced from a kubernetes secret.
+ * Metadata that was passed via labels should be stored here.
+ */
+public class KubernetesSourcedCredential {
+
+    private final IdCredentials idCredentials;
+    private final Set<String> itemGroups;
+
+    public KubernetesSourcedCredential(IdCredentials idCredentials, Set<String> itemGroups) {
+        this.idCredentials = idCredentials;
+        this.itemGroups = itemGroups;
+    }
+
+    public IdCredentials getIdCredentials() {
+        return idCredentials;
+    }
+
+    public Set<String> getItemGroups() {
+        return itemGroups;
+    }
+
+    public String getId() {
+        return idCredentials.getId();
+    }
+
+    @Nullable
+    public CredentialsScope getScope() {
+        return idCredentials.getScope();
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtils.java
@@ -29,6 +29,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
@@ -37,10 +38,9 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.google.common.collect.Sets;
-import com.google.common.base.Splitter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -67,7 +67,7 @@ public abstract class SecretUtils {
     static final String JENKINS_IO_CREDENTIALS_SCOPE_LABEL = "jenkins.io/credentials-scope";
 
     /** Optional annotation containing a list of job folders this credential is available to */
-    static final String JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION = "jenkins.io/credentials-item-group";
+    static final String JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION = "jenkins.io/credentials-store-locations";
 
     /**
      * Convert a String representation of the base64 encoded bytes of a UTF-8 String back to a String. 
@@ -134,7 +134,7 @@ public abstract class SecretUtils {
 
     /**
      * Gets all item-group scopes from a secret.
-     * Format of the annotation: ["/job/thisIsJobA/", "/job/thisIsJobB/"]
+     * Format of the annotation: "['thisIsJobA', 'thisIsJobB', 'thisIsJobC/thisIsJobD']"
      *
      * @param s the secret whose item-group scope we want to obtain.
      * @return a set of all item-group scopes
@@ -144,9 +144,17 @@ public abstract class SecretUtils {
         if (itemListString == null) {
             return Collections.emptySet();
         }
+        if(!itemListString.startsWith("[") || !itemListString.endsWith("]")) {
+            return Collections.emptySet();
+        }
         itemListString = itemListString.trim();
         itemListString = itemListString.substring(1, itemListString.length()-1);
-        return Sets.newHashSet(Splitter.on(", ").trimResults().omitEmptyStrings().split(itemListString));
+
+        return Arrays.stream(itemListString.split(", "))
+                .filter(p -> !p.isEmpty())
+                .map(String::trim)
+                .map(p -> p.substring(1, p.length()-1))
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/SecretUtils.java
@@ -30,13 +30,17 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Locale;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Optional;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.google.common.collect.Sets;
+import com.google.common.base.Splitter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -62,6 +66,8 @@ public abstract class SecretUtils {
 
     static final String JENKINS_IO_CREDENTIALS_SCOPE_LABEL = "jenkins.io/credentials-scope";
 
+    /** Optional annotation containing a list of job folders this credential is available to */
+    static final String JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION = "jenkins.io/credentials-item-group";
 
     /**
      * Convert a String representation of the base64 encoded bytes of a UTF-8 String back to a String. 
@@ -113,6 +119,10 @@ public abstract class SecretUtils {
         CredentialsScope scope = CredentialsScope.GLOBAL;
         String label = s.getMetadata().getLabels().get(JENKINS_IO_CREDENTIALS_SCOPE_LABEL);
         if (label != null) {
+            if(!getCredentialItemScopes(s).isEmpty()) {
+                throw new CredentialsConvertionException(JENKINS_IO_CREDENTIALS_SCOPE_LABEL + " can not be combined with " +
+                        JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION);
+            }
             try {
                 scope = CredentialsScope.valueOf(label.toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException exception) {
@@ -120,6 +130,23 @@ public abstract class SecretUtils {
             }
         }
         return scope;
+    }
+
+    /**
+     * Gets all item-group scopes from a secret.
+     * Format of the annotation: ["/job/thisIsJobA/", "/job/thisIsJobB/"]
+     *
+     * @param s the secret whose item-group scope we want to obtain.
+     * @return a set of all item-group scopes
+     */
+    public static Set<String> getCredentialItemScopes(Secret s) {
+        String itemListString = s.getMetadata().getAnnotations().get(SecretUtils.JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION);
+        if (itemListString == null) {
+            return Collections.emptySet();
+        }
+        itemListString = itemListString.trim();
+        itemListString = itemListString.substring(1, itemListString.length()-1);
+        return Sets.newHashSet(Splitter.on(", ").trimResults().omitEmptyStrings().split(itemListString));
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
@@ -88,7 +88,7 @@ public class KubernetesCredentialsProviderTest {
     @Test
     public void startWatchingForSecrets_Scoped() throws IOException {
         Map<String, String> s4Annotations = new HashMap<>();
-        s4Annotations.put(SecretUtils.JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION, "[/my-item-group/]");
+        s4Annotations.put(SecretUtils.JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION, "['my-item-group']");
         Secret s4 = createSecret("s4", Map.of(), s4Annotations);
 
         server.expect().withPath("/api/v1/namespaces/test/secrets?labelSelector=jenkins.io%2Fcredentials-type")
@@ -104,7 +104,7 @@ public class KubernetesCredentialsProviderTest {
         provider.startWatchingForSecrets();
 
         ItemGroup group = mock(ItemGroup.class);
-        when(group.getUrl()).thenReturn("my-item-group/");
+        when(group.getFullName()).thenReturn("my-item-group");
 
         List<UsernamePasswordCredentials> credentials = provider.getCredentials(UsernamePasswordCredentials.class, group, ACL.SYSTEM);
         assertEquals("credentials", 1, credentials.size());

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
@@ -5,14 +5,18 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.fabric8.kubernetes.client.WatcherException;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,10 +86,36 @@ public class KubernetesCredentialsProviderTest {
     }
 
     @Test
+    public void startWatchingForSecrets_Scoped() throws IOException {
+        Map<String, String> s4Annotations = new HashMap<>();
+        s4Annotations.put(SecretUtils.JENKINS_IO_CREDENTIALS_ITEM_GROUP_ANNOTATION, "[/my-item-group/]");
+        Secret s4 = createSecret("s4", Map.of(), s4Annotations);
+
+        server.expect().withPath("/api/v1/namespaces/test/secrets?labelSelector=jenkins.io%2Fcredentials-type")
+                .andReturn(200, new SecretListBuilder()
+                        .withNewMetadata()
+                        .withResourceVersion("1")
+                        .endMetadata()
+                        .addToItems(s4)
+                        .build())
+                .once();
+
+        KubernetesCredentialProvider provider = new MockedKubernetesCredentialProvider();
+        provider.startWatchingForSecrets();
+
+        ItemGroup group = mock(ItemGroup.class);
+        when(group.getUrl()).thenReturn("my-item-group/");
+
+        List<UsernamePasswordCredentials> credentials = provider.getCredentials(UsernamePasswordCredentials.class, group, ACL.SYSTEM);
+        assertEquals("credentials", 1, credentials.size());
+        assertTrue("secret s4 exists", credentials.stream().anyMatch(c -> "s4".equals(((UsernamePasswordCredentialsImpl) c).getId())));
+    }
+
+    @Test
     public void startWatchingForSecrets() {
-        Secret s1 = createSecret("s1", null);
-        Secret s2 = createSecret("s2", null);
-        Secret s3 = createSecret("s3", null);
+        Secret s1 = createSecret("s1", (CredentialsScope) null);
+        Secret s2 = createSecret("s2", (CredentialsScope) null);
+        Secret s3 = createSecret("s3", (CredentialsScope) null);
 
         // returns s1 and s3, the credentials map should be reset to this list
         server.expect().withPath("/api/v1/namespaces/test/secrets?labelSelector=jenkins.io%2Fcredentials-type")
@@ -170,12 +200,26 @@ public class KubernetesCredentialsProviderTest {
     }
 
     private Secret createSecret(String name, CredentialsScope scope) {
+        Map<String, String> labels = Map.of(
+                "jenkins.io/credentials-scope", scope == null ? "global" : scope.name().toLowerCase(Locale.ROOT)
+        );
+        return createSecret(name, labels);
+    }
+
+    private Secret createSecret(String name, Map<String, String> labels) {
+        return createSecret(name, labels, Map.of());
+    }
+
+    private Secret createSecret(String name, Map<String, String> labels, Map<String, String> annotations) {
+        Map<String, String> labelsCopy = new HashMap<>(labels);
+        labelsCopy.put("jenkins.io/credentials-type", "usernamePassword");
+
         return new SecretBuilder()
                 .withNewMetadata()
                 .withNamespace("test")
                 .withName(name)
-                .addToLabels("jenkins.io/credentials-type", "usernamePassword")
-                .addToLabels("jenkins.io/credentials-scope", scope == null ? "global" : scope.name().toLowerCase(Locale.ROOT))
+                .addToLabels(labelsCopy)
+                .addToAnnotations(annotations)
                 .endMetadata()
                 .addToData("username", "bXlVc2VybmFtZQ==")
                 .addToData("password", "UGEkJHdvcmQ=")


### PR DESCRIPTION
This supersedes #40. 
Linked issues: 
https://issues.jenkins.io/browse/JENKINS-63416
https://issues.jenkins.io/browse/JENKINS-53105

This PR introduces folder-scoping of credentials by adding the `jenkins.io/credentials-item-group` annotation. Credentials will then only be available to the specified ItemGroup/Folder/Job + children. 

Improvements to #40 :
- Introduced a new type for storing parsed credential data apart from IdCredential
- Syntax of annotation is now `["/job/thisIsJobA/", "/job/thisIsJobB/job/nestedJob/"]` allowing for all paths to be parsed to list
- All paths must begin and end with '/'
- Previous label is now an annotation