### PR TITLE
Show test failures with Jackson 2 API 2.19.0 and another plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,19 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <!-- Special case to show plugin BOM issues related to mockito use in KubernetesCredentialsProviderTest -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <!-- Jackson 2 API 2.19.0 fails tests when included with Bitbucket Branch Source or Artifact Manager for S3 or Pipeline Graph View in tests -->
+      <version>2.19.0-404.vb_b_0fd2fea_e10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-bitbucket-branch-source</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- Jenkins is not synced to central so we need to bootstrap -->


### PR DESCRIPTION
## Show test failures with Jackson 2 API 2.19.0 and another plugin

Jenkins plugin BOM fails all tests in convertor classes when run with Jackson 2 API 2.19.0.  The failure message is:

```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NoClassDefFoundError: com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer [in thread "main"]
	at com.fasterxml.jackson.datatype.jsr310.JavaTimeModule.setupModule(JavaTimeModule.java:157)
	at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:835)
	at com.fasterxml.jackson.databind.ObjectMapper.registerModules(ObjectMapper.java:1017)
	at io.fabric8.kubernetes.client.utils.KubernetesSerialization.configureMapper(KubernetesSerialization.java:92)
	at io.fabric8.kubernetes.client.utils.KubernetesSerialization.<init>(KubernetesSerialization.java:88)
	at io.fabric8.kubernetes.client.utils.KubernetesSerialization.<init>(KubernetesSerialization.java:76)
	at io.fabric8.kubernetes.client.utils.Serialization.<clinit>(Serialization.java:38)
```

The ToEmptyObjectSerializer class is included in Jackson API 2.19.0 just as it was included in earlier releases.

Failures are recorded at:

* https://ci.jenkins.io/job/Tools/job/bom/job/master/4594/testReport/com.cloudbees.jenkins.plugins.kubernetes_credentials_provider/

Passing tests are:

* LabelSelectorExpressionsTest
* SecretUtilsTest
* AbstractConverterTest

All other tests fail when run with Jackson API 2.19.0 and a test dependency for any of the following plugins:

* Bitbucket Branch Source
* Artifact Manager for S3
* Pipeline Graph View

I didn't search for other examples, since those three examples seem sufficient.

### Testing done

Tested with plugin BOM pull request:

* https://github.com/jenkinsci/bom/pull/5088

Tested that several different plugins show the same issue when tested with this plugin:

* Bitbucket Branch Source
* Artifact Manager for S3
* Pipeline Graph View

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
